### PR TITLE
Improve ActiveSupport 3.0 Compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Hoe.plugin :git
 Hoe.spec 'rubigen' do
   developer 'Dr Nic Williams', 'drnicwilliams@gmail.com'
   developer 'Jeremy Kemper', 'jeremy@bitsweat.net'
-  extra_deps << ['activesupport','~> 2.3.5']
+  extra_deps << ['activesupport','>= 2.3.5']
   extra_dev_deps << ['mocha','>= 0.9.8']
   extra_dev_deps << ['cucumber','>= 0.6.2']
   extra_dev_deps << ['shoulda','>= 2.10.3']

--- a/lib/rubigen.rb
+++ b/lib/rubigen.rb
@@ -1,13 +1,7 @@
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
-begin
-  # if you are using rubygems, fix to 2.3.5
-  gem 'activesupport', '~> 2.3.5'
-rescue
-end
-
-require 'active_support' 
+require 'active_support/all' 
 
 module RubiGen
   VERSION = '1.5.5'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,7 @@
 require 'rubygems'
+require 'shoulda'
 require 'test/unit'
 require File.dirname(__FILE__) + '/../lib/rubigen'
 require 'rubigen/helpers/generator_test_helper'
 include RubiGen
-require "shoulda"
-require "shoulda/test_unit"
 require 'mocha'


### PR DESCRIPTION
Hello Dr. Nic,

My project, Adhearsion, has had some problems being compatible with Rails/ActiveSupport 3.0 because our dependency, RubiGen, is tied to AS2.3.  Some people have resorted to downgrading RubiGen to 1.5.2 since that version does not list an explicit AS version dependency.  But that also means that they have been able to use RubiGen with ActiveSupport 3.0 without trouble.

I've set out to try to make sure that RubiGen is actually compatible with ActiveSupport 3.0.  This pull request is the result of my work.  The only change of consequence is that the require line now uses 'active_support/all' instead of just 'active_support'.  This change is compatible with both AS2.3 and AS3.0.  The other changes were needed by newer versions of shoulda to run unit tests.  I can confirm that only two unit tests are failing after this change, and they were failing under AS2.3 in the same way.

Please let me know if you have any questions.  If you would consider including these changes in RubiGen 1.5.6 I would appreciate it, as would users of Adhearsion.

Best,
/BAK/
