### PR TITLE
Depend on activesupport < 3.2.0, since it's not compatible.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec 'rubigen' do
   developer 'Dr Nic Williams', 'drnicwilliams@gmail.com'
   developer 'Jeremy Kemper', 'jeremy@bitsweat.net'
   developer 'Ben Klang', 'bklang@mojolingo.com'
-  extra_deps << ['activesupport','>= 2.3.5']
+  extra_deps << ['activesupport','>= 2.3.5', "< 3.2.0"]
   # Needed when loading active_support/all
   extra_deps << ['i18n']
   extra_dev_deps << ['rspec','~>1.3']


### PR DESCRIPTION
activesupport 3.2.0 appears to break rubigen:

`undefined method `write_inheritable_attribute' for RubiGen::Base:Class`

This just adds a stricter dependency. Fingers crossed for a quick release :)
