### PR TITLE
Fix deprecation warnings from Rubygems.

### DIFF
--- a/lib/rubigen/lookup.rb
+++ b/lib/rubigen/lookup.rb
@@ -281,8 +281,7 @@ module RubiGen
     private
       def generator_full_paths
         @generator_full_paths ||=
-          Gem::source_index.inject({}) do |latest, name_gem|
-            name, gem = name_gem
+          Gem::Specification.inject({}) do |latest, gem|
             hem = latest[gem.name]
             latest[gem.name] = gem if hem.nil? or gem.version > hem.version
             latest


### PR DESCRIPTION
The following warnings exist in the current release:

``````
NOTE: Gem.source_index is deprecated, use Specification. It will be removed on or after 2011-11-01.
Gem.source_index called from /Users/fijabakk/src/git/rubigen/lib/rubigen/lookup.rb:284.
NOTE: Gem::SourceIndex#each is deprecated with no replacement. It will be removed on or after 2011-11-01.

I've replaced ```Gem.source_index#each``` with ```Gem::Specification.each```. I've only tested it against Rubygems 1.8.15, but the removal dates that relying on it being there should be fine.

``````
