### PR TITLE
run command for rubigen

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 #!/usr/bin/env rake
+require 'bundler/setup'
 require "bundler/gem_tasks"
 require "rake/testtask"
 

--- a/lib/rubigen/commands.rb
+++ b/lib/rubigen/commands.rb
@@ -289,6 +289,11 @@ module RubiGen
         system("git add -v #{relative_destination}") if options[:git]
       end
 
+      def run(command, relative_path = '')
+        logger.run command
+        system("cd #{destination_path(relative_path)} && #{command}")
+      end
+
       # Checks if the source and the destination file are identical. If
       # passed a block then the source file is a template that needs to first
       # be evaluated before being compared to the destination.


### PR DESCRIPTION
Hi drnic.

I'm not sure, if i understood the classes correctly.
I added a run-method to RubiGen::Commands::Create that starts a system call with the given parameter.
I'd add some tests, but currently don't get the tests running, i get:
undefined method `write_inheritable_attribute' for RubiGen::Base:Class
/home/rjung/Projects/rubigen/lib/rubigen/options.rb:31:in`default_options'

I think, this'd be a good idea, for example to run git or svn checkins (that's, what i intend to use it for, there are probably other possibillities).

Regards,
-Rainer
