### PR TITLE
Support RubiGen::VERSION for module name consistency and add a test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+rubigen.iml
+vendor/ruby
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
-#!/usr/bin/env rake
 require "bundler/gem_tasks"
-require "rake/testtask"
+require 'rake/testtask'
 
 require './lib/rubigen'
 

--- a/app_generators/ruby_app/ruby_app_generator.rb
+++ b/app_generators/ruby_app/ruby_app_generator.rb
@@ -1,8 +1,8 @@
 require 'rbconfig'
 
 class RubyAppGenerator < RubiGen::Base
-  DEFAULT_SHEBANG = File.join(Config::CONFIG['bindir'],
-                              Config::CONFIG['ruby_install_name'])
+  DEFAULT_SHEBANG = File.join(RbConfig::CONFIG['bindir'],
+                              RbConfig::CONFIG['ruby_install_name'])
 
   default_options   :shebang => DEFAULT_SHEBANG
   

--- a/generators/install_rubigen_scripts/install_rubigen_scripts_generator.rb
+++ b/generators/install_rubigen_scripts/install_rubigen_scripts_generator.rb
@@ -1,6 +1,6 @@
 class InstallRubigenScriptsGenerator < RubiGen::Base
-  DEFAULT_SHEBANG = File.join(Config::CONFIG['bindir'],
-                              Config::CONFIG['ruby_install_name'])
+  DEFAULT_SHEBANG = File.join(RbConfig::CONFIG['bindir'],
+                              RbConfig::CONFIG['ruby_install_name'])
   
   default_options :shebang => DEFAULT_SHEBANG
   

--- a/lib/rubigen.rb
+++ b/lib/rubigen.rb
@@ -1,6 +1,8 @@
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
+require 'rubigen/version'
+
 require 'active_support/all' 
 
 require 'rubigen/base'

--- a/lib/rubigen/version.rb
+++ b/lib/rubigen/version.rb
@@ -1,3 +1,7 @@
 module Rubigen
   VERSION = "1.5.8"
 end
+
+module RubiGen
+  VERSION = Rubigen::VERSION
+end

--- a/rubigen.gemspec
+++ b/rubigen.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |gem|
   gem.version       = Rubigen::VERSION
   
   gem.add_dependency 'activesupport', '>= 2.3.5', "< 3.2.0"
+  gem.add_dependency 'i18n'
+  gem.add_dependency 'mocha','>= 0.9.8'
+  gem.add_dependency 'launchy'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'i18n'
   gem.add_development_dependency 'rspec','~>1.3'
-  gem.add_development_dependency 'mocha','>= 0.9.8'
   gem.add_development_dependency 'cucumber','>= 0.6.2'
   gem.add_development_dependency 'shoulda','>= 2.10.3'
-  gem.add_development_dependency 'launchy'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,4 +4,4 @@ require 'test/unit'
 require File.dirname(__FILE__) + '/../lib/rubigen'
 require 'rubigen/helpers/generator_test_helper'
 include RubiGen
-require 'mocha'
+require 'mocha/setup'

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -1,0 +1,30 @@
+require 'test/unit'
+require 'rubigen'
+
+class TestRubigenVersion < Test::Unit::TestCase
+
+  # Called before every test method runs. Can be used
+  # to set up fixture information.
+  def setup
+    # Do nothing
+  end
+
+  # Called after every test method runs. Can be used to tear
+  # down fixture information.
+
+  def teardown
+    # Do nothing
+  end
+
+  # Fake test
+  def test_version
+
+    # To change this template use File | Settings | File Templates.
+    begin
+      assert(RubiGen::VERSION == Rubigen::VERSION, "Expect RubiGen::VERSION to be defined" )
+    rescue
+      fail("Expect RubiGen::VERSION to be defined")
+    end
+
+  end
+end


### PR DESCRIPTION
Ran into a situation with newgem which referred to RubiGen::VERSION so I thought it best to support that in addition to Rubigen::VERSION
